### PR TITLE
mewpoke: use a default close() in IDiscovery

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/Dns.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/Dns.java
@@ -33,7 +33,7 @@ public class Dns implements IDiscovery {
             final ClusterManager clusterManager = couchbaseCluster.clusterManager(username, password);
             final List<BucketSettings> buckets = clusterManager.getBuckets();
             final JsonArray clusterNodes = clusterManager.info().raw().getArray("nodes");
-            Map<Service, Set<InetSocketAddress>> servicesNodes = new HashMap<>();
+            final Map<Service, Set<InetSocketAddress>> servicesNodes = new HashMap<>();
 
             buckets.forEach(b -> {
                 final String bucketname = b.name();
@@ -41,8 +41,8 @@ public class Dns implements IDiscovery {
                 final Set<InetSocketAddress> nodes = new HashSet<>();
 
                 clusterNodes.forEach(n -> {
-                    String ipaddr = ((JsonObject) n).getString("hostname").split(":")[0];
-                    Integer port = ((JsonObject) n).getObject("ports").getInt("direct");
+                    final String ipaddr = ((JsonObject) n).getString("hostname").split(":")[0];
+                    final Integer port = ((JsonObject) n).getObject("ports").getInt("direct");
                     logger.debug("Node {} for bucket {}", ipaddr, bucketname);
                     nodes.add(new InetSocketAddress(ipaddr, port));
                 });
@@ -59,10 +59,5 @@ public class Dns implements IDiscovery {
                 couchbaseCluster.disconnect();
             }
         }
-    }
-
-    @Override
-    public void close() {
-        return;
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/IDiscovery.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/IDiscovery.java
@@ -10,7 +10,7 @@ public interface IDiscovery extends AutoCloseable {
 
     Map<Service, Set<InetSocketAddress>> getServicesNodesFor();
 
-    void close();
+    default void close(){}
 
     static boolean areServicesEquals(final Map<Service, Set<InetSocketAddress>> ori, Map<Service, Set<InetSocketAddress>> neo)
     {


### PR DESCRIPTION
- IDiscovery is AutoCloseable. Some implementations (in particular
Consul) have to be dispose explicitly. But some (Dns/CouchbaseDiscovery)
needs not, so a default close() method that do nothing is much
confortable: it does not force implementation to implement close() if
they dont care.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/7)
<!-- Reviewable:end -->
