### PR TITLE
Refactor update topology

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseMonitor.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseMonitor.java
@@ -334,7 +334,7 @@ public class CouchbaseMonitor implements AutoCloseable {
         try {
             client.disconnect();
         } catch (Exception e) {
-            logger.error("Cannot close couchbase client properly for {}", serviceName, e);
+            logger.error("Cannot disconnect couchbase client properly for {}", serviceName, e);
         }
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/IDiscovery.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/IDiscovery.java
@@ -1,30 +1,12 @@
 package com.criteo.nosql.mewpoke.discovery;
 
 import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public interface IDiscovery extends AutoCloseable {
 
     Map<Service, Set<InetSocketAddress>> getServicesNodesFor();
 
     default void close() {
-    }
-
-    static boolean areServicesEquals(final Map<Service, Set<InetSocketAddress>> ori, Map<Service, Set<InetSocketAddress>> neo) {
-        if (ori.size() != neo.size()) {
-            return false;
-        }
-
-        for (Map.Entry<Service, Set<InetSocketAddress>> e : ori.entrySet()) {
-            Set<InetSocketAddress> addresses = neo.getOrDefault(e.getKey(), Collections.emptySet());
-            if (addresses.size() != e.getValue().size() || !e.getValue().containsAll(addresses)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/Service.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/Service.java
@@ -35,4 +35,16 @@ public class Service {
         result = 31 * result + (bucketName != null ? bucketName.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("Service {cluster='")
+                .append(clusterName)
+                .append("', bucket='")
+                .append(bucketName)
+                .append("'}")
+                .toString();
+
+    }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedMonitor.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedMonitor.java
@@ -149,6 +149,10 @@ public class MemcachedMonitor implements AutoCloseable {
 
     @Override
     public void close() {
-        client.shutdown();
+        try {
+            client.shutdown();
+        } catch (Exception e) {
+            logger.error("Cannot shutdown memcached client properly for {} ", serviceName, e);
+        }
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedRunnerAbstract.java
@@ -2,10 +2,7 @@ package com.criteo.nosql.mewpoke.memcached;
 
 import java.net.InetSocketAddress;
 import java.util.*;
-import java.util.stream.Collectors;
 
-import com.criteo.nosql.mewpoke.discovery.ConsulDiscovery;
-import com.criteo.nosql.mewpoke.discovery.CouchbaseDiscovery;
 import com.criteo.nosql.mewpoke.discovery.IDiscovery;
 import com.criteo.nosql.mewpoke.discovery.Service;
 import org.slf4j.Logger;
@@ -23,8 +20,8 @@ public abstract class MemcachedRunnerAbstract implements AutoCloseable, Runnable
     private final long refreshDiscoveryPeriodInMs;
 
     protected Map<Service, Set<InetSocketAddress>> services;
-    protected Map<Service, Optional<MemcachedMonitor>> monitors;
-    protected Map<Service, MemcachedMetrics> metrics;
+    protected final Map<Service, Optional<MemcachedMonitor>> monitors;
+    protected final Map<Service, MemcachedMetrics> metrics;
 
     public MemcachedRunnerAbstract(Config cfg, IDiscovery discovery) {
         this.cfg = cfg;
@@ -106,29 +103,29 @@ public abstract class MemcachedRunnerAbstract implements AutoCloseable, Runnable
             return;
         }
 
-        // Check if topology has changed
-        if (IDiscovery.areServicesEquals(services, new_services)) {
-            logger.trace("No topology change.");
-            return;
-        }
-
-        logger.info("Topology changed. Monitors are updating...");
-        // Clean old monitors
-        monitors.values().forEach(mo -> mo.ifPresent(MemcachedMonitor::close));
-        metrics.values().forEach(MemcachedMetrics::close);
+        // Dispose old monitors
+        services.forEach((service, addresses) -> {
+            if (!Objects.equals(addresses, new_services.get(service))) {
+                logger.info("{} has changed, its monitor will be disposed.", service);
+                monitors.remove(service)
+                        .ifPresent(mon -> mon.close());
+                metrics.remove(service)
+                        .close();
+            }
+        });
 
         // Create new ones
-        services = new_services;
         final long timeoutInMs = cfg.getService().getTimeoutInSec() * 1000L;
-        monitors = services.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> MemcachedMonitor.fromNodes(e.getKey(), e.getValue(),
-                        timeoutInMs)
-                ));
 
-        metrics = new HashMap<>(monitors.size());
-        for (Service service : monitors.keySet()) {
-            metrics.put(service, new MemcachedMetrics(service));
-        }
+        new_services.forEach((service, new_addresses) -> {
+            if (!Objects.equals(services.get(service), new_addresses)) {
+                logger.info("A new Monitor for {} will be created.", service);
+                monitors.put(service, MemcachedMonitor.fromNodes(service, new_addresses, timeoutInMs));
+                metrics.put(service, new MemcachedMetrics(service));
+            }
+        });
+
+        services = new_services;
     }
 
     protected abstract void poke();
@@ -136,14 +133,12 @@ public abstract class MemcachedRunnerAbstract implements AutoCloseable, Runnable
     @Override
     public void close() {
         discovery.close();
-        monitors.values().forEach(mo -> mo.ifPresent(m -> {
-            try {
-                m.close();
-            } catch (Exception e) {
-                logger.error("Error when releasing resources", e);
-            }
-        }));
-        metrics.values().forEach(MemcachedMetrics::close);
+        monitors.values().stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(mon -> mon.close());
+        metrics.values()
+                .forEach(metric -> metric.close());
     }
 
     private enum EVENT {


### PR DESCRIPTION
- Catch exceptions in '*Monitor#close()', so caller do not have manage
them.
- Change 'Runner#updateTopology', now monitors and metrics maps are not
fully recreated on each topology changes. Instead we dispose only
monitors/metrics of services that has changed or disapeared, and we
insert new monitors/metrics for services that has changed or the new ones.
- Delete 'IDiscovery#areEquals', unused with the new algo
- Override 'Service#toString' to improve logging
- TODO: improve Metric::close to not clear ALL metrics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/11)
<!-- Reviewable:end -->
