### PR TITLE
Refactor update topology

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
@@ -20,8 +20,8 @@ public abstract class CouchbaseRunnerAbstract implements AutoCloseable, Runnable
     private final long refreshDiscoveryPeriodInMs;
 
     protected Map<Service, Set<InetSocketAddress>> services;
-    protected Map<Service, Optional<CouchbaseMonitor>> monitors;
-    protected Map<Service, CouchbaseMetrics> metrics;
+    protected final Map<Service, Optional<CouchbaseMonitor>> monitors;
+    protected final Map<Service, CouchbaseMetrics> metrics;
 
     public CouchbaseRunnerAbstract(Config cfg, IDiscovery discovery) {
         this.cfg = cfg;
@@ -30,8 +30,8 @@ public abstract class CouchbaseRunnerAbstract implements AutoCloseable, Runnable
         this.refreshDiscoveryPeriodInMs = Long.parseLong(cfg.getApp().getOrDefault("refreshDiscoveryPeriodInSec", "300")) * 1000L;
 
         this.services = Collections.emptyMap();
-        this.monitors = Collections.emptyMap();
-        this.metrics = Collections.emptyMap();
+        this.monitors = new HashMap<>();
+        this.metrics = new HashMap<>();
     }
 
     @Override
@@ -101,32 +101,32 @@ public abstract class CouchbaseRunnerAbstract implements AutoCloseable, Runnable
             return;
         }
 
-        // Check if topology changed
-        if (IDiscovery.areServicesEquals(services, new_services)) {
-            logger.trace("No topology change.");
-            return;
-        }
-
-        logger.info("Topology changed. Monitors are updating...");
-        // Dispose old monitors and metrics
-        monitors.values().forEach(mo -> mo.ifPresent(CouchbaseMonitor::close));
-        metrics.values().forEach(CouchbaseMetrics::close);
+        // Dispose old monitors
+        services.forEach((service, addresses) -> {
+            if (!Objects.equals(addresses, new_services.get(service))) {
+                logger.info("{} has changed, its monitor will be disposed.", service);
+                monitors.remove(service)
+                        .ifPresent(mon -> mon.close());
+                metrics.remove(service)
+                        .close();
+            }
+        });
 
         // Create new ones
-        services = new_services;
         final long timeoutInMs = cfg.getService().getTimeoutInSec() * 1000L;
-        monitors = services.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> CouchbaseMonitor.fromNodes(e.getKey(), e.getValue(),
-                        timeoutInMs,
-                        cfg.getService().getUsername(),
-                        cfg.getService().getPassword(),
-                        cfg.getCouchbaseStats())
-                ));
+        final String username = cfg.getService().getUsername();
+        final String password = cfg.getService().getPassword();
+        final Config.CouchbaseStats cbStats = cfg.getCouchbaseStats();
+        new_services.forEach((service, new_addresses) -> {
+            if (!Objects.equals(services.get(service), new_addresses)) {
+                logger.info("A new Monitor for {} will be created.", service);
+                monitors.put(service, CouchbaseMonitor.fromNodes(service, new_addresses, timeoutInMs,
+                        username, password, cbStats));
+                metrics.put(service, new CouchbaseMetrics(service));
+            }
+        });
 
-        metrics = new HashMap<>(monitors.size());
-        for (Service service : monitors.keySet()) {
-            metrics.put(service, new CouchbaseMetrics(service));
-        }
+        services = new_services;
     }
 
     protected abstract void poke();

--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/IDiscovery.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/IDiscovery.java
@@ -1,30 +1,12 @@
 package com.criteo.nosql.mewpoke.discovery;
 
 import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public interface IDiscovery extends AutoCloseable {
 
     Map<Service, Set<InetSocketAddress>> getServicesNodesFor();
 
     default void close() {
-    }
-
-    static boolean areServicesEquals(final Map<Service, Set<InetSocketAddress>> ori, Map<Service, Set<InetSocketAddress>> neo) {
-        if (ori.size() != neo.size()) {
-            return false;
-        }
-
-        for (Map.Entry<Service, Set<InetSocketAddress>> e : ori.entrySet()) {
-            Set<InetSocketAddress> addresses = neo.getOrDefault(e.getKey(), Collections.emptySet());
-            if (addresses.size() != e.getValue().size() || !e.getValue().containsAll(addresses)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/Service.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/Service.java
@@ -35,4 +35,16 @@ public class Service {
         result = 31 * result + (bucketName != null ? bucketName.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("Service {cluster='")
+                .append(clusterName)
+                .append("', bucket='")
+                .append(bucketName)
+                .append("'}")
+                .toString();
+
+    }
 }


### PR DESCRIPTION
- Change 'Runner#updateTopology', now monitors and metrics maps are not
fully recreated on each topology changes. Instead we dispose only
monitors/metrics of services that has changed or disapeared, and we
insert new monitors/metrics for services that has changed or the new ones.
- Delete 'IDiscovery#areEquals', unused with the new algo
- Override 'Service#toString' to improve logging
- TODO: improve Metric::close to not clear ALL metrics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/13)
<!-- Reviewable:end -->

  