### PR TITLE
Fix node port on staticcfg for latencies metrics

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/CouchbaseDiscovery.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/CouchbaseDiscovery.java
@@ -48,10 +48,14 @@ public class CouchbaseDiscovery implements IDiscovery {
                 final String bucketname = b.name();
                 final Service srv = new Service(clustername, bucketname);
                 final Set<InetSocketAddress> nodes = new HashSet<>();
+                final BucketSettings bucketsettings = clusterManager.getBucket(bucketname);
 
                 clusterNodes.forEach(n -> {
                     final String ipaddr = ((JsonObject) n).getString("hostname").split(":")[0];
-                    final Integer port = ((JsonObject) n).getObject("ports").getInt("direct");
+                    final Integer port = bucketsettings.port();
+                    if (port == 0){
+                        logger.error("Could not get dedicated port for bucket {}, latency won't work", bucketname);
+                    }
                     logger.debug("Node {} for bucket {}", ipaddr, bucketname);
                     nodes.add(new InetSocketAddress(ipaddr, port));
                 });


### PR DESCRIPTION
- By default on staticcfg, Couchbase used direct port (11210) for
  latencies request and failed. Fix this by using dedicated port
  (supporting ASCII protocol without authentication) if set (if not log
  an error)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/16)
<!-- Reviewable:end -->
