### PR TITLE
Discovery must NOT be closed by Runner

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/Main.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/Main.java
@@ -42,7 +42,7 @@ public class Main {
         final HTTPServer server = new HTTPServer(httpServerPort, true);
 
         // Memcached client is too verbose, we keep only SEVERE messages
-        java.util.logging.Logger memcachedLogger = java.util.logging.Logger.getLogger("net.spy.memcached");
+        final java.util.logging.Logger memcachedLogger = java.util.logging.Logger.getLogger("net.spy.memcached");
         memcachedLogger.setLevel(Level.SEVERE);
         System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.SunLogger");
 
@@ -57,9 +57,13 @@ public class Main {
                     logger.info("Run {}", runnerType);
                     ((Runnable)runner).run();
                 } catch (Exception e) {
-                    logger.error("An unexpected exception was thrown", e);
+                    logger.error("An unexpected exception was caught. We will rerun {}", runnerType, e);
+                } catch (Error e) {
+                    logger.error("An unexpected error was thrown, that indicates serious problems. The program will exit", e);
+                    discovery.close();
+                    server.stop();
+                    throw e;
                 }
-
             }
         }
     }

--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
@@ -136,7 +136,6 @@ public abstract class CouchbaseRunnerAbstract implements AutoCloseable, Runnable
 
     @Override
     public void close() {
-        discovery.close();
         monitors.values().forEach(mo -> mo.ifPresent(m ->
                 m.close()
         ));

--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/Service.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/Service.java
@@ -45,6 +45,5 @@ public class Service {
                 .append(bucketName)
                 .append("'}")
                 .toString();
-
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedRunnerAbstract.java
@@ -133,7 +133,6 @@ public abstract class MemcachedRunnerAbstract implements AutoCloseable, Runnable
 
     @Override
     public void close() {
-        discovery.close();
         monitors.values().forEach(mo -> mo.ifPresent(m ->
                 m.close()
         ));


### PR DESCRIPTION
- The discovery must not be closed when we close the Runner, or it does
not work on retry
- Add an explicit Error management: to close the discovery and print a
relevant log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/17)
<!-- Reviewable:end -->
