### PR TITLE
Add Custom CollectorRegistry

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/Main.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/Main.java
@@ -9,10 +9,12 @@ import com.criteo.nosql.mewpoke.discovery.IDiscovery;
 import com.criteo.nosql.mewpoke.memcached.MemcachedRunnerLatency;
 import com.criteo.nosql.mewpoke.memcached.MemcachedRunnerStats;
 import com.criteo.nosql.mewpoke.memcached.MemcachedRunnerStatsItems;
+import com.criteo.nosql.mewpoke.prometheus.MetaCollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.util.logging.Level;
 
 
@@ -39,7 +41,7 @@ public class Main {
         // daemon=true, so if the scheduler is stopped, the JVM does not wait for http server termination
         final int httpServerPort = Integer.parseInt(cfg.getApp().getOrDefault("httpServerPort", "8080"));
         logger.info("Starting an http server on port {}", httpServerPort);
-        final HTTPServer server = new HTTPServer(httpServerPort, true);
+        final HTTPServer server = new HTTPServer(new InetSocketAddress("0.0.0.0", httpServerPort), MetaCollectorRegistry.metaRegistry, true);
 
         // Memcached client is too verbose, we keep only SEVERE messages
         final java.util.logging.Logger memcachedLogger = java.util.logging.Logger.getLogger("net.spy.memcached");

--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseMetrics.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseMetrics.java
@@ -1,6 +1,8 @@
 package com.criteo.nosql.mewpoke.couchbase;
 
 import com.criteo.nosql.mewpoke.discovery.Service;
+import com.criteo.nosql.mewpoke.prometheus.MetaCollectorRegistry;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Summary;
 
@@ -9,13 +11,14 @@ import java.util.Map;
 
 public class CouchbaseMetrics implements AutoCloseable {
 
-    static final Gauge UP = Gauge.build()
+    private final CollectorRegistry registry = new CollectorRegistry(true);
+    private final Gauge UP = Gauge.build()
             .name("couchbase_up")
             .help("Are the servers up?")
             .labelNames("cluster", "bucket", "instance")
-            .register();
+            .register(registry);
 
-    static final Summary LATENCY = Summary.build()
+    private final Summary LATENCY = Summary.build()
             .name("couchbase_latency")
             .help("latencies observed by instance and command")
             .labelNames("cluster", "bucket", "instance", "command")
@@ -24,31 +27,31 @@ public class CouchbaseMetrics implements AutoCloseable {
             .quantile(0.5, 0.05)
             .quantile(0.9, 0.01)
             .quantile(0.99, 0.001)
-            .register();
+            .register(registry);
 
-    static final Gauge OPERATIONS = Gauge.build()
+    private final Gauge OPERATIONS = Gauge.build()
             .name("couchbase_operations")
             .help("Cluster ongoing operations")
             .labelNames("cluster", "operation")
-            .register();
+            .register(registry);
 
-    static final Gauge MEMBERSHIP = Gauge.build()
+    private final Gauge MEMBERSHIP = Gauge.build()
             .name("couchbase_membership")
             .help("Cluster membership status")
             .labelNames("cluster", "membership")
-            .register();
+            .register(registry);
 
-    static final Gauge STATS = Gauge.build()
+    private final Gauge STATS = Gauge.build()
             .name("couchbase_stats")
             .help("Cluster API Stats")
             .labelNames("cluster", "bucket", "instance", "name")
-            .register();
+            .register(registry);
 
-    static final Gauge XDCR = Gauge.build()
+    private final Gauge XDCR = Gauge.build()
             .name("couchbase_xdcr")
             .help("Cluster API Stats XDCR")
             .labelNames("cluster", "bucket", "remotecluster", "name")
-            .register();
+            .register(registry);
 
     private final String clusterName;
     private final String bucketName;
@@ -57,6 +60,8 @@ public class CouchbaseMetrics implements AutoCloseable {
     public CouchbaseMetrics(final Service service) {
         this.clusterName = service.getClusterName();
         this.bucketName = service.getBucketName().replace('.', '_');
+
+        MetaCollectorRegistry.metaRegistry.register(this.registry);
     }
 
     public void updateRebalanceOps(final boolean rebalanceOngoing) {
@@ -105,12 +110,17 @@ public class CouchbaseMetrics implements AutoCloseable {
 
     @Override
     public void close() {
-        // FIXME we should remove only metrics with the labels cluster=clustername, bucket=bucketName
+        // TODO: Not sure if all those clear on collector are necessary
+        // but as I found no information in prometheus regarding if it keeps some references
+        // So let be safe, and clean everything
         UP.clear();
         LATENCY.clear();
         OPERATIONS.clear();
         MEMBERSHIP.clear();
         STATS.clear();
         XDCR.clear();
+        registry.clear();
+
+        MetaCollectorRegistry.metaRegistry.unregister(registry);
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public abstract class CouchbaseRunnerAbstract implements AutoCloseable, Runnable {
 

--- a/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/memcached/MemcachedRunnerAbstract.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public abstract class MemcachedRunnerAbstract implements AutoCloseable, Runnable {
 

--- a/src/main/java/com/criteo/nosql/mewpoke/prometheus/MetaCollectorRegistry.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/prometheus/MetaCollectorRegistry.java
@@ -1,0 +1,100 @@
+package com.criteo.nosql.mewpoke.prometheus;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class MetaCollectorRegistry extends CollectorRegistry {
+    public static final MetaCollectorRegistry metaRegistry = new MetaCollectorRegistry();
+    private final CopyOnWriteArrayList<CollectorRegistry> registries = new CopyOnWriteArrayList<>();
+
+    public MetaCollectorRegistry() {
+    }
+
+    @Override
+    public void register(Collector m) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void unregister(Collector m) {
+        throw new NotImplementedException();
+    }
+
+    public void register(CollectorRegistry m) {
+        registries.add(m);
+    }
+
+    public void unregister(CollectorRegistry m) {
+        registries.remove(m);
+    }
+
+    @Override
+    public void clear() {
+        registries.clear();
+    }
+
+    @Override
+    public Enumeration<Collector.MetricFamilySamples> metricFamilySamples() {
+        return new MetricFamilySamplesEnumeration();
+    }
+
+    @Override
+    public Enumeration<Collector.MetricFamilySamples> filteredMetricFamilySamples(Set<String> includedNames) {
+        return new MetricFamilySamplesEnumeration();
+    }
+
+    @Override
+    public Double getSampleValue(String name) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Double getSampleValue(String name, String[] labelNames, String[] labelValues) {
+        throw new NotImplementedException();
+    }
+
+    class MetricFamilySamplesEnumeration implements Enumeration<Collector.MetricFamilySamples> {
+
+        private final Iterator<CollectorRegistry> it = registries.iterator();
+        private Enumeration<Collector.MetricFamilySamples> next = null;
+
+        @Override
+        public boolean hasMoreElements() {
+            if (next != null && next.hasMoreElements()) {
+                return true;
+            }
+
+            while (it.hasNext()) {
+                next = it.next().metricFamilySamples();
+                if (next.hasMoreElements()) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public Collector.MetricFamilySamples nextElement() {
+            if (next != null && next.hasMoreElements()) {
+                return next.nextElement();
+            }
+
+            while (it.hasNext()) {
+                next = it.next().metricFamilySamples();
+                if (next.hasMoreElements()) {
+                    return next.nextElement();
+                }
+            }
+
+            throw new NoSuchElementException();
+        }
+    }
+}


### PR DESCRIPTION
   + In order to not wipe every metrics on topology refresh,
     implements a custom CollectorRegistry that will tracks individual
     registry for us

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/22)
<!-- Reviewable:end -->
