### PR TITLE
Ugly workaround to manage consul tags changes

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/discovery/ConsulDiscovery.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/discovery/ConsulDiscovery.java
@@ -56,20 +56,18 @@ public class ConsulDiscovery implements IDiscovery {
     }
 
     private Map<Service, Set<InetSocketAddress>> getServicesNodesForImpl(List<String> tags) {
-        ConsulClient client = new ConsulClient(host, port);
-        final String[] platformSuffixes = new String[]{"-eu", "-us", "-as"};
+        final ConsulClient client = new ConsulClient(host, port);
 
-        List<Map.Entry<String, List<String>>> services =
+        final List<Map.Entry<String, List<String>>> services =
                 client.getCatalogServices(params).getValue().entrySet().stream()
-                        .filter(entry -> !Collections.disjoint(entry.getValue(), tags)
-                                && Arrays.stream(platformSuffixes).noneMatch(suffix -> entry.getKey().toLowerCase().endsWith(suffix)))
+                        .filter(entry -> !Collections.disjoint(entry.getValue(), tags))
                         .map(entry -> {
                             logger.info("Found service matching {}", entry.getKey());
                             return entry;
                         })
                         .collect(toList());
 
-        Map<Service, Set<InetSocketAddress>> servicesNodes = new HashMap<>(services.size());
+        final Map<Service, Set<InetSocketAddress>> servicesNodes = new HashMap<>(services.size());
         for (Map.Entry<String, List<String>> service : services) {
             final Set<InetSocketAddress> nodes = new HashSet<>();
             final Service[] srv = new Service[]{null};


### PR DESCRIPTION
- In order to manage change in Consul tags, we support both 'cluster=*' and 'cluster-*'.
- We must find a cleaner way to make this logic configurable (or useless)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/24)
<!-- Reviewable:end -->
