### PR TITLE
Add support bucket authentication for static discovery

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -31,6 +31,7 @@ Mewpoke get all infos from his configuration's file ```config.yml```
 - `timeoutInSec`: timeout for service requests
 - `username`: Couchbase username
 - `password`: Couchbase password
+- `bucketpassword`: bucket's password specified in the "Access Control" part of Bucket settings (all buckets within the cluster should have the same password). This feature will disable dedicated port used by Memcached driver for set/get. So latency won't be available.
 
 ## couchbaseStats
 - `bucket`: list all bucket stats exported (if empty, will export all metrics)

--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,7 @@ service:
   timeoutInSec: 60
   username: Administrator
   password: password
+  #bucketpassword: password
 
 couchbaseStats:
   bucket: # API : /pools/default/buckets/MYBUCKET/nodes/MYNODE:PORT/stats

--- a/src/main/java/com/criteo/nosql/mewpoke/config/Config.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/config/Config.java
@@ -123,6 +123,7 @@ public final class Config {
         private List<String> tags;
         private String username;
         private String password;
+        private String bucketpassword;
 
         public String getType() {
             return type;
@@ -142,6 +143,10 @@ public final class Config {
 
         public String getPassword() {
             return password;
+        }
+
+        public String getBucketpassword() {
+            return bucketpassword;
         }
     }
 }

--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseRunnerAbstract.java
@@ -115,15 +115,10 @@ public abstract class CouchbaseRunnerAbstract implements AutoCloseable, Runnable
         });
 
         // Create new ones
-        final long timeoutInMs = cfg.getService().getTimeoutInSec() * 1000L;
-        final String username = cfg.getService().getUsername();
-        final String password = cfg.getService().getPassword();
-        final Config.CouchbaseStats cbStats = cfg.getCouchbaseStats();
         new_services.forEach((service, new_addresses) -> {
             if (!Objects.equals(services.get(service), new_addresses)) {
                 logger.info("A new Monitor for {} will be created.", service);
-                monitors.put(service, CouchbaseMonitor.fromNodes(service, new_addresses, timeoutInMs,
-                        username, password, cbStats));
+                monitors.put(service, CouchbaseMonitor.fromNodes(service, new_addresses, cfg));
                 metrics.put(service, new CouchbaseMetrics(service));
             }
         });


### PR DESCRIPTION
- Support bucket authentication for static discovery. Password should be
  the same for all buckets. This will avoid latencies metrics for
  couchbase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/31)
<!-- Reviewable:end -->
