### PR TITLE
Refactor CouchbaseMonitor

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,11 +10,11 @@ discovery:
 #    timeoutInSec: 10
 #    readConsistency: STALE
 #    tags:
-#     - couchbase-memcached
-#     - cluster=CLUSTERNAME
-#     - bucket=BUCKETNAME
+#      - couchbase-memcached
+#      - cluster-CLUSTERNAME
+#      - bucket-BUCKETNAME
   staticDns:
-    clustername: cluster01
+    clustername: mycluster
     host: localhost
 
 service:
@@ -26,15 +26,15 @@ service:
 
 couchbaseStats:
   bucket: # API : /pools/default/buckets/MYBUCKET/nodes/MYNODE:PORT/stats
-     - ep_mem_high_wat
-     - vb_active_resident_items_ratio
-     - vb_replica_resident_items_ratio
-     - ep_mem_low_wat
-     - ep_diskqueue_items
-     - ep_oom_errors
-     - ep_tmp_oom_errors
-     - ep_max_size
+    - ep_mem_high_wat
+    - vb_active_resident_items_ratio
+    - vb_replica_resident_items_ratio
+    - ep_mem_low_wat
+    - ep_diskqueue_items
+    - ep_oom_errors
+    - ep_tmp_oom_errors
+    - ep_max_size
   xdcr: # API: replications/XDCR_UUID/MYBUCKET_SOURCE/MYBUCKET_DESTINATION/
-     - bandwidth_usage
-     - percent_completeness
-     - changes_left
+    - bandwidth_usage
+    - percent_completeness
+    - changes_left


### PR DESCRIPTION
- Do not hardcode 8091. Add an attribute named 'httpDirectPort'.
- Sort attributes to be consistent with the constructor.
- Move NodeLocatorHelper in constructor (unused elsewhere).
- Simplify CouchbaseMonitor by replacing CouchbaseStats by two separated attributes 'bucketStatsNames' and 'xdcrStatsNames'.
- Improve logs, in particular in case of unsuccess HTTP request now we provide the code and the reasonPhrase.
- Fix indentation in config.yml example.
- Fix tags in config.yml (replace bucket= by bucket-).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/36)
<!-- Reviewable:end -->
