### PR TITLE
Fix integration tests based on docker

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,7 @@ gradle build
 ```
 Then deploy containers:
 ```sh
-cd docker
+cd tests
 docker-compose up -d
 ```
 

--- a/tests/mewpoke/config/config_couchbase.yml
+++ b/tests/mewpoke/config/config_couchbase.yml
@@ -1,19 +1,9 @@
 app:
   measurementPeriodInSec: 30
-  refreshDiscoveryPeriodInSec: 120
+  refreshDiscoveryPeriodInSec: 60
   httpServerPort: 8082
 
 discovery:
-  refreshEveryMin: 1
-#  consul:
-#    host: consul.service.consul
-#    port: 8500
-#    timeoutInSec: 10
-#    readConsistency: STALE
-#    tags:
-#     - couchbase-memcached
-     #- cluster=CLUSTERNAME
-     #- bucket=BUCKETNAME
   staticDns:
     clustername: cluster01
     host: couchbase01

--- a/tests/mewpoke/config/config_couchbase_stats.yml
+++ b/tests/mewpoke/config/config_couchbase_stats.yml
@@ -1,19 +1,9 @@
 app:
   measurementPeriodInSec: 30
-  refreshDiscoveryPeriodInSec: 120
+  refreshDiscoveryPeriodInSec: 60
   httpServerPort: 8080
 
 discovery:
-  refreshEveryMin: 1
-#  consul:
-#    host: consul.service.consul
-#    port: 8500
-#    timeoutInSec: 10
-#    readConsistency: STALE
-#    tags:
-#     - couchbase-memcached
-     #- cluster=CLUSTERNAME
-     #- bucket=BUCKETNAME
   staticDns:
     clustername: cluster01
     host: couchbase01

--- a/tests/mewpoke/config/config_memcache.yml
+++ b/tests/mewpoke/config/config_memcache.yml
@@ -1,19 +1,9 @@
 app:
-  measurementPeriodInSec: 30
-  refreshDiscoveryPeriodInSec: 120
+  measurementPeriodInSec: 10
+  refreshDiscoveryPeriodInSec: 60
   httpServerPort: 8081
 
 discovery:
-  refreshEveryMin: 1
-#  consul:
-#    host: host: consul.service.consul
-#    port: 8500
-#    timeoutInSec: 10
-#    readConsistency: STALE
-#    tags:
-#     - couchbase-memcached
-     #- cluster=CLUSTERNAME
-     #- bucket=BUCKETNAME
   staticDns:
     clustername: cluster01
     host: couchbase01


### PR DESCRIPTION
- mewpoke configuration was not up to date: discovery.refreshEveryMin was disappeared
- decrease measurementPeriodInSec to avoid NaN on out-of-date Prometheus Summary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/38)
<!-- Reviewable:end -->
