### PR TITLE
fix nullpointerexception on CouchbaseMonitor

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseMonitor.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/couchbase/CouchbaseMonitor.java
@@ -127,8 +127,10 @@ public class CouchbaseMonitor implements AutoCloseable {
         final String username = config.getService().getUsername();
         final String password = config.getService().getPassword();
         final String bucketName = service.getBucketName();
-        final List<String> bucketStatsNames = config.getCouchbaseStats().getBucket();
-        final List<String> xdcrStatsNames = config.getCouchbaseStats().getXdcr();
+        final List<String> bucketStatsNames = (config.getCouchbaseStats() != null ? config.getCouchbaseStats().getBucket()
+            : null);
+        final List<String> xdcrStatsNames = (config.getCouchbaseStats() != null ? config.getCouchbaseStats().getXdcr()
+            : null);
 
         CouchbaseCluster client = null;
         Bucket bucket = null;


### PR DESCRIPTION
This exception prevents some metrics from being properly exposed
we verify first the existence  of a CouchebaseStats section in the config file before trying to retrieve both the Bucket and Xdcr sections

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/40)
<!-- Reviewable:end -->
