### PR TITLE
Update consul discovery mechanism to get list of nodes from couchbase

### DIFF
--- a/src/main/java/com/criteo/nosql/mewpoke/Main.java
+++ b/src/main/java/com/criteo/nosql/mewpoke/Main.java
@@ -52,10 +52,10 @@ public class Main {
         // If an unexpected exception occurs, we retry
         for (; ; ) {
             logger.info("Loading {}", runnerType);
-            try(AutoCloseable runner = getRunner(runnerType, cfg, discovery)){
+            try (AutoCloseable runner = getRunner(runnerType, cfg, discovery)) {
                 try {
                     logger.info("Run {}", runnerType);
-                    ((Runnable)runner).run();
+                    ((Runnable) runner).run();
                 } catch (Exception e) {
                     logger.error("An unexpected exception was caught. We will rerun {}", runnerType, e);
                 } catch (Error e) {
@@ -73,7 +73,7 @@ public class Main {
         final Config.StaticDiscovery staticCfg = cfg.getDiscovery().getStaticDns();
         if (consulCfg != null) {
             logger.info("Consul discovery will be used");
-            return new ConsulDiscovery(consulCfg);
+            return new ConsulDiscovery(consulCfg, cfg.getService().getUsername(), cfg.getService().getPassword());
         }
         if (staticCfg != null) {
             logger.info("Static Couchbase discovery will be used");
@@ -99,8 +99,8 @@ public class Main {
                 default:
                     final Class clazz = Class.forName(type);
                     return (AutoCloseable) clazz
-                            .getConstructor(Config.class, IDiscovery.class)
-                            .newInstance(cfg, discovery);
+                        .getConstructor(Config.class, IDiscovery.class)
+                        .newInstance(cfg, discovery);
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Cannot load the service " + type, e);


### PR DESCRIPTION
List of nodes can be updated on consul side but not on the couchbase cluster.
Due to that if we recreate the monitor from the list of nodes in consul we can still have a monitor querying a node that will be removed.
Then when it is really rermoved from couchbase we are not recreating the monitor which leads to some prometheus metrics from this removed node to
be still here.
With that change we will get list of nodes from consul and then query couchbase from thise nde list to get the list of nodes frm couchbase point of view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/criteo/mewpoke/45)
<!-- Reviewable:end -->
